### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1-buster AS builder
+
+WORKDIR /build
+COPY . /build
+RUN cd /build/cmd && go build -v
+
+FROM debian:buster-slim
+
+EXPOSE 8080
+COPY --from=builder /build/cmd/cmd /pnrsh
+ENTRYPOINT /pnrsh
+

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ pnr.sh uses normal and public APIs to obtain reservation information that is alr
 
 
 pnr.sh is open-source and freely licensed under the MIT license.
+
+## Building with Docker
+
+A `Dockerfile` is included for easily building and deploying `pnr.sh`. By default, it will listen on `0.0.0.0:8080`. This can be overridden by changing the `PORT` environment variable. 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,7 @@ func listenAddress() string {
 		return "0.0.0.0:" + port
 	}
 
-	return "127.0.0.1:8080"
+	return "0.0.0.0:8080"
 }
 
 func main() {


### PR DESCRIPTION
👋 Hi @iangcarroll!

I hope this PR finds you well - this adds a multistage Docker build that produces a Debian-based image for this project. The only code change needed was modifying the listener (if there is no `PORT` environment variable) to listen on `0.0.0.0` instead of localhost, so that Docker can route requests to the service.

I'm happy to change anything around if you'd prefer, I just wanted to do this to easily deploy on my end! 