### PR TITLE
Add SSL certs to final Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN cd /build/cmd && go build -v
 FROM debian:buster-slim
 
 EXPOSE 8080
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /build/cmd/cmd /pnrsh
 ENTRYPOINT /pnrsh
-


### PR DESCRIPTION
This PR adds the standard CA certificates to the final Docker image.

Without this, running the server within Docker fails to connect to Delta (and presumably any other `https` endpoints) with an error like this:

> Post "https://api.delta.com/api2/mobile/getPnr": x509: certificate signed by unknown authority

(I'm guessing you're not experiencing this on Heroku because the standard system certs are already in the dyno.)