### PR TITLE
fix: remove extraneous email address in AC PNR display

### DIFF
--- a/cmd/templates/aircanada-show.html
+++ b/cmd/templates/aircanada-show.html
@@ -68,10 +68,6 @@
                 </div>
                 <table class="table">
                   <tbody>
-                    <tr>
-                      <td><strong>Email</strong></td>
-                      <td>fdskfdsf</td>
-                    </tr>
                     {{ if .HasEmailAddress }}
                     <tr>
                       <td><strong>Email</strong></td>


### PR DESCRIPTION
Looks like there was some test data left in the contact display table on the AC PNR html page — this PR removes it.