### PR TITLE
Add support for qualifyingmiles.com calculation.

### DIFF
--- a/cmd/templates/delta-show.html
+++ b/cmd/templates/delta-show.html
@@ -9,15 +9,13 @@
         <strong>The tickets attached to your reservation have a different fare class than the segments in your reservation.</strong> If your departure date is approaching, this will likely prevent you from checking in, but you can contact Delta to request an immediate reissue of your ticket.
     </div>
     {{ end }}
-      
-    <ul class="nav nav-pills">
-        <li class="nav-item">
-          <a class="nav-link" style="color: black">Tools</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link active" href="{{.PNR.Fare.SMCalcLink}}" target="_blank">Calculate Earnings</a>
-        </li>
-    </ul>
+
+    <div class="d-flex" style="gap: 0.5em;">
+        <div class="p-1" style="color: black">Tools</div>
+        <a class="btn btn-primary" href="{{.PNR.Fare.SMCalcLink}}" target="_blank">skymilescalculator.com</a>
+        <a class="btn btn-secondary" href="{{.PNR.Fare.QMCalcLink}}" target="_blank">qualifyingmiles.com</a>
+    </div>
+
     <hr />
 
     <div class="row">

--- a/pkg/delta/pnr/convert.go
+++ b/pkg/delta/pnr/convert.go
@@ -132,6 +132,7 @@ func convertFare(res RetrievePnrResponse, pnr *PNR) {
 	pnr.Fare = convertedFare
 	pnr.Fare.EstimatedMQD = estimateMQD(pnr)
 	pnr.Fare.SMCalcLink = generateSmcalcLink(pnr)
+	pnr.Fare.QMCalcLink = generateQMCalcLink(pnr)
 }
 
 func convertReceiptResponse(res RetrievePnrResponse, pnr *PNR) {

--- a/pkg/delta/pnr/types.go
+++ b/pkg/delta/pnr/types.go
@@ -78,6 +78,7 @@ type Fare struct {
 	FareBasisCode     string
 	EstimatedMQD      string
 	SMCalcLink        string
+	QMCalcLink        string
 }
 
 // Raw API response from Delta.


### PR DESCRIPTION
Per a request on FlyerTalk, this commit adds support for calculating earnings on Delta PNRs with qualifyingmiles.com. I kept the link to skymilescalculator.com as well in case folks want to use that.

I don't have an Aeromexico or Virgin Atlantic PNR to test with, so I did not update those airlines' earnings calculations.